### PR TITLE
Fix Prisma review type import in product page

### DIFF
--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -4,9 +4,9 @@ import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import AddToCartButton from "@/components/product/AddToCartButton";
-import type { Review, User } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 
-type ReviewWithUser = Review & { user: User };
+type ReviewWithUser = Prisma.ReviewGetPayload<{ include: { user: true } }>;
 
 export default async function ProductPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;


### PR DESCRIPTION
## Summary
- Use Prisma's `ReviewGetPayload` type to define review-with-user, replacing direct `Review` and `User` imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a33e3fa2c48331847da545af273a35