### PR TITLE
Debug flutter build product json error

### DIFF
--- a/FLUTTER_BUILD_FIX.md
+++ b/FLUTTER_BUILD_FIX.md
@@ -1,0 +1,98 @@
+# Flutter Build Error Fix: Missing `_$ProductFromJson`
+
+## Error
+```
+lib/shared/models/product.dart:129:12: Error: Method not found: '_$ProductFromJson'.
+    return _$ProductFromJson(normalizedJson);
+           ^^^^^^^^^^^^^^^^^
+```
+
+## Root Cause
+The `json_serializable` package generates code like `_$ProductFromJson` and `_$ProductToJson` at build time. This error occurs when:
+1. The code generation hasn't been run yet
+2. The generated `.g.dart` files are missing or outdated
+3. The build_runner cache is corrupted
+
+## Solution
+
+### Step 1: Clean the project
+```bash
+flutter clean
+```
+
+### Step 2: Get dependencies
+```bash
+flutter pub get
+```
+
+### Step 3: Run code generation
+Choose ONE of these commands:
+
+**Option A: One-time generation**
+```bash
+flutter pub run build_runner build --delete-conflicting-outputs
+```
+
+**Option B: Watch mode (auto-regenerates on file changes)**
+```bash
+flutter pub run build_runner watch --delete-conflicting-outputs
+```
+
+### Step 4: Verify the generated file exists
+Check that `lib/shared/models/product.g.dart` has been created.
+
+### Step 5: Run your app again
+```bash
+flutter run -d ZY22D54TZZ
+```
+
+## If the error persists
+
+1. **Check your pubspec.yaml has these dependencies:**
+```yaml
+dependencies:
+  json_annotation: ^4.8.1
+
+dev_dependencies:
+  build_runner: ^2.4.6
+  json_serializable: ^6.7.1
+```
+
+2. **Verify your product.dart file has the correct annotations:**
+```dart
+import 'package:json_annotation/json_annotation.dart';
+
+part 'product.g.dart';
+
+@JsonSerializable()
+class Product {
+  // ... your fields ...
+  
+  factory Product.fromJson(Map<String, dynamic> json) => _$ProductFromJson(json);
+  Map<String, dynamic> toJson() => _$ProductToJson(this);
+}
+```
+
+3. **If still failing, try a complete rebuild:**
+```bash
+flutter clean
+flutter pub get
+flutter pub run build_runner clean
+flutter pub run build_runner build --delete-conflicting-outputs
+flutter run -d ZY22D54TZZ
+```
+
+## Quick Command Sequence
+Run these commands in order:
+```bash
+cd C:\Users\Zkratos\Desktop\agrihub
+flutter clean
+flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs
+flutter run -d ZY22D54TZZ
+```
+
+## Additional Notes
+- The `--delete-conflicting-outputs` flag automatically resolves conflicts in generated files
+- If you're actively developing, use `watch` mode to auto-regenerate on saves
+- Generated `.g.dart` files should be committed to git unless specified otherwise in your `.gitignore`

--- a/FLUTTER_ERROR_SOLUTION_SUMMARY.md
+++ b/FLUTTER_ERROR_SOLUTION_SUMMARY.md
@@ -1,0 +1,71 @@
+# Flutter Build Error - Solution Summary
+
+## Problem
+Your Flutter app fails to build with the error:
+```
+lib/shared/models/product.dart:129:12: Error: Method not found: '_$ProductFromJson'.
+```
+
+## Quick Fix (Windows)
+
+### Option 1: Use the automated script
+1. Copy `fix_flutter_build.bat` to your project: `C:\Users\Zkratos\Desktop\agrihub\`
+2. Run it:
+```cmd
+fix_flutter_build.bat
+```
+
+### Option 2: Manual commands
+Open PowerShell in your project directory and run:
+```powershell
+cd C:\Users\Zkratos\Desktop\agrihub
+flutter clean
+flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs
+flutter run -d ZY22D54TZZ
+```
+
+## Why This Happens
+The `json_serializable` package in Flutter generates helper methods like `_$ProductFromJson` and `_$ProductToJson` automatically. These are created in `.g.dart` files (e.g., `product.g.dart`).
+
+When you:
+- Clone a new repository
+- Switch branches
+- Add/modify model classes with `@JsonSerializable()` annotations
+- Delete generated files
+
+...you need to regenerate these files using `build_runner`.
+
+## What Each Command Does
+
+1. **`flutter clean`** - Removes build artifacts and caches
+2. **`flutter pub get`** - Installs/updates dependencies from pubspec.yaml
+3. **`flutter pub run build_runner build`** - Generates the missing `.g.dart` files
+4. **`--delete-conflicting-outputs`** - Overwrites existing generated files if they conflict
+
+## Verification
+After running the fix, you should see:
+- A file created: `lib/shared/models/product.g.dart`
+- The build should succeed without errors
+- Your app should launch on the device
+
+## For Future Development
+To avoid this issue when actively developing:
+
+**Use watch mode** - automatically regenerates code when you save files:
+```bash
+flutter pub run build_runner watch --delete-conflicting-outputs
+```
+
+Keep this running in a separate terminal while you code.
+
+## Files Created
+1. `FLUTTER_BUILD_FIX.md` - Detailed troubleshooting guide
+2. `fix_flutter_build.bat` - Windows automated fix script
+3. `fix_flutter_build.sh` - Linux/Mac automated fix script
+4. `FLUTTER_ERROR_SOLUTION_SUMMARY.md` - This summary
+
+## Next Steps
+1. Run the fix using either the script or manual commands
+2. Verify the app builds successfully
+3. If issues persist, check the detailed guide in `FLUTTER_BUILD_FIX.md`

--- a/QUICK_FIX.md
+++ b/QUICK_FIX.md
@@ -1,0 +1,32 @@
+# ⚡ QUICK FIX - Flutter Build Error
+
+## The Problem
+```
+Error: Method not found: '_$ProductFromJson'.
+```
+
+## The Solution (Copy & Paste This)
+
+Open PowerShell in your project folder and run:
+
+```powershell
+cd C:\Users\Zkratos\Desktop\agrihub
+flutter clean
+flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs
+flutter run -d ZY22D54TZZ
+```
+
+## That's It! 🎉
+
+Your app should now build and run successfully.
+
+---
+
+## What Just Happened?
+You regenerated the missing auto-generated code files that Flutter's `json_serializable` package needs.
+
+## Need More Help?
+- **Detailed guide**: See `FLUTTER_BUILD_FIX.md`
+- **Automated script**: Run `fix_flutter_build.bat`
+- **Full explanation**: See `FLUTTER_ERROR_SOLUTION_SUMMARY.md`

--- a/fix_flutter_build.bat
+++ b/fix_flutter_build.bat
@@ -1,0 +1,43 @@
+@echo off
+REM Flutter Build Fix Script for Windows
+REM Fixes the "_$ProductFromJson not found" error
+
+echo ========================================
+echo Flutter Build Fix Script
+echo ========================================
+echo.
+
+echo Step 1/4: Cleaning Flutter project...
+call flutter clean
+if errorlevel 1 (
+    echo ERROR: Flutter clean failed!
+    pause
+    exit /b 1
+)
+echo ✓ Clean completed
+echo.
+
+echo Step 2/4: Getting dependencies...
+call flutter pub get
+if errorlevel 1 (
+    echo ERROR: Flutter pub get failed!
+    pause
+    exit /b 1
+)
+echo ✓ Dependencies installed
+echo.
+
+echo Step 3/4: Running code generation...
+call flutter pub run build_runner build --delete-conflicting-outputs
+if errorlevel 1 (
+    echo ERROR: Code generation failed!
+    pause
+    exit /b 1
+)
+echo ✓ Code generated successfully
+echo.
+
+echo Step 4/4: Running Flutter app...
+call flutter run -d ZY22D54TZZ
+
+pause

--- a/fix_flutter_build.sh
+++ b/fix_flutter_build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Flutter Build Fix Script for Linux/Mac
+# Fixes the "_$ProductFromJson not found" error
+
+echo "========================================"
+echo "Flutter Build Fix Script"
+echo "========================================"
+echo ""
+
+echo "Step 1/4: Cleaning Flutter project..."
+flutter clean
+if [ $? -ne 0 ]; then
+    echo "ERROR: Flutter clean failed!"
+    exit 1
+fi
+echo "✓ Clean completed"
+echo ""
+
+echo "Step 2/4: Getting dependencies..."
+flutter pub get
+if [ $? -ne 0 ]; then
+    echo "ERROR: Flutter pub get failed!"
+    exit 1
+fi
+echo "✓ Dependencies installed"
+echo ""
+
+echo "Step 3/4: Running code generation..."
+flutter pub run build_runner build --delete-conflicting-outputs
+if [ $? -ne 0 ]; then
+    echo "ERROR: Code generation failed!"
+    exit 1
+fi
+echo "✓ Code generated successfully"
+echo ""
+
+echo "Step 4/4: Build complete! You can now run your app with:"
+echo "flutter run -d <device-id>"
+echo ""


### PR DESCRIPTION
Add documentation and automated scripts to resolve the `_$ProductFromJson` Flutter build error caused by missing `json_serializable` code generation.

The `json_serializable` package requires `build_runner` to generate `.g.dart` files containing methods like `_$ProductFromJson`. This error typically occurs when these generated files are missing or outdated, often after cloning a repository or switching branches, and the `build_runner` command has not been executed. The added files provide clear steps and automation to regenerate these necessary files.

---
<a href="https://cursor.com/background-agent?bcId=bc-d30add71-4e60-45cd-8201-876d0ff6aaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d30add71-4e60-45cd-8201-876d0ff6aaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

