### PR TITLE
Debug checkout and image loading errors

### DIFF
--- a/components/checkout/CustomerInfoForm.tsx
+++ b/components/checkout/CustomerInfoForm.tsx
@@ -114,8 +114,12 @@ export function CustomerInfoForm({ onNext, onBack }: CustomerInfoFormProps) {
     }
 
     // Update checkout state with all new fields
+    // Combine firstName and lastName into name for validation
+    const fullName = `${formData.firstName} ${formData.lastName}`.trim()
+    
     updateCustomer({
       email: formData.email,
+      name: fullName, // Add combined name for validation
       firstName: formData.firstName,
       lastName: formData.lastName,
       phone: formData.phone,

--- a/hooks/use-checkout.ts
+++ b/hooks/use-checkout.ts
@@ -141,6 +141,7 @@ export const useCheckout = create<CheckoutState>()(
             // Customer info step
             return !!(
               state.customer.email &&
+              state.customer.name &&
               state.customer.firstName &&
               state.customer.lastName &&
               state.customer.phone &&
@@ -148,6 +149,7 @@ export const useCheckout = create<CheckoutState>()(
               state.customer.quartier &&
               state.customer.adresseDetaillee &&
               state.customer.email.includes('@') &&
+              state.customer.name.length >= 3 &&
               state.customer.firstName.length >= 2 &&
               state.customer.lastName.length >= 2 &&
               state.customer.phone.length >= 9 &&


### PR DESCRIPTION
Combine `firstName` and `lastName` into a `name` field for checkout validation to resolve "Nom complet requis" error.

The checkout process failed because the Zod validation schema expected a `name` field, which was not being explicitly created from the separate `firstName` and `lastName` inputs. This change ensures the `name` field is present and validated.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec0e061c-3670-4038-a52f-ea101f2fef73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec0e061c-3670-4038-a52f-ea101f2fef73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

