### PR TITLE
Debug image and database errors

### DIFF
--- a/ERREURS_CORRIGEES.md
+++ b/ERREURS_CORRIGEES.md
@@ -1,0 +1,118 @@
+# Corrections des Erreurs - FlawlessBeauty
+
+## Résumé des Problèmes Identifiés
+
+### 1. ❌ Erreur Prisma : `Product.displaySettings` n'existe pas
+
+**Message d'erreur :**
+```
+The column `Product.displaySettings` does not exist in the current database.
+```
+
+**Cause :**
+Le client Prisma généré était obsolète et contenait une référence à une colonne `displaySettings` qui avait été supprimée du schéma.
+
+**Solution appliquée :**
+```bash
+npx prisma generate
+```
+✅ Le client Prisma a été régénéré avec le schéma actuel
+
+### 2. ❌ Images 404 (manquantes)
+
+**Images manquantes :**
+- `/images/shampoing.jpg`
+- `/images/fond-teint.jpg`
+- `/images/vitamines.jpg`
+
+**Cause :**
+Ces images sont référencées dans la base de données mais n'existent pas dans le dossier `public/images/`
+
+**Solution appliquée :**
+Une route API a été créée pour corriger automatiquement les URLs d'images dans la base de données :
+- `app/api/admin/fix-images/route.ts`
+
+**Mappings de remplacement :**
+- `shampoing.jpg` → `p31-1.jpg` (image existante)
+- `fond-teint.jpg` → `p21-1.jpg` (image existante)
+- `vitamines.jpg` → `p12-1.jpg` (image existante)
+
+### 3. ✅ Nettoyage du cache Next.js
+
+Le cache `.next/` a été supprimé pour forcer la régénération complète de l'application.
+
+## Actions à Effectuer
+
+### Étape 1 : Démarrer le serveur de développement
+
+```bash
+npm run dev
+```
+
+### Étape 2 : Corriger les images en base de données
+
+Une fois le serveur démarré, exécutez cette commande pour corriger les URLs d'images :
+
+```bash
+curl -X POST http://localhost:3000/api/admin/fix-images
+```
+
+**OU** visitez cette URL dans votre navigateur (en POST) :
+`http://localhost:3000/api/admin/fix-images`
+
+### Étape 3 : Vérifier que tout fonctionne
+
+1. ✅ Visitez la page d'accueil : `http://localhost:3000`
+2. ✅ Visitez le catalogue : `http://localhost:3000/catalog`
+3. ✅ Vérifiez le checkout (plus d'erreur displaySettings)
+4. ✅ Vérifiez que les images s'affichent correctement
+
+## Vérification des Corrections
+
+### Client Prisma
+```bash
+# Vérifier que le client est à jour
+npx prisma generate
+```
+
+### Images
+```bash
+# Lister les images disponibles
+ls -la public/images/
+```
+
+### Base de données
+```bash
+# Vérifier les produits avec URLs d'images
+# (nécessite l'accès à la base de données)
+```
+
+## Notes Importantes
+
+1. **Route API temporaire** : La route `/api/admin/fix-images` peut être supprimée après utilisation ou conservée pour des corrections futures.
+
+2. **Images de remplacement** : Les images utilisées en remplacement sont des images génériques. Pour une meilleure UX, remplacez-les par des images appropriées pour chaque produit.
+
+3. **Prévention** : 
+   - Toujours vérifier que les images existent avant de les référencer en base de données
+   - Utiliser un système de gestion d'images centralisé (comme Uploadthing déjà configuré)
+   - Valider les URLs d'images lors de la création/modification de produits
+
+## Fichiers Modifiés
+
+- ✅ `prisma/schema.prisma` - Schéma sans displaySettings (déjà correct)
+- ✅ Client Prisma régénéré
+- ✅ `.next/` supprimé et à régénérer
+- ✅ `app/api/admin/fix-images/route.ts` - Route API de correction créée
+
+## Prochaines Étapes
+
+1. ✅ Démarrer le serveur (`npm run dev`)
+2. ✅ Exécuter la correction des images via l'API
+3. ✅ Tester l'application complète
+4. ✅ (Optionnel) Ajouter des images appropriées pour remplacer les placeholders
+5. ✅ (Optionnel) Supprimer la route API de correction si non nécessaire
+
+---
+
+**Statut :** 🟢 Corrections appliquées - Tests requis

--- a/app/api/admin/fix-images/route.ts
+++ b/app/api/admin/fix-images/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function POST() {
+  try {
+    // Rechercher les produits avec images manquantes
+    const productsToFix = await prisma.product.findMany({
+      where: {
+        OR: [
+          { imageUrl: { contains: 'shampoing.jpg' } },
+          { imageUrl: { contains: 'fond-teint.jpg' } },
+          { imageUrl: { contains: 'vitamines.jpg' } },
+        ],
+      },
+    })
+
+    const results = []
+
+    for (const product of productsToFix) {
+      let newImageUrl = product.imageUrl
+
+      // Remplacer les images manquantes par des images existantes
+      if (product.imageUrl?.includes('shampoing.jpg')) {
+        newImageUrl = '/images/p31-1.jpg'
+      } else if (product.imageUrl?.includes('fond-teint.jpg')) {
+        newImageUrl = '/images/p21-1.jpg'
+      } else if (product.imageUrl?.includes('vitamines.jpg')) {
+        newImageUrl = '/images/p12-1.jpg'
+      }
+
+      if (newImageUrl !== product.imageUrl) {
+        await prisma.product.update({
+          where: { id: product.id },
+          data: { imageUrl: newImageUrl },
+        })
+        results.push({
+          id: product.id,
+          name: product.name,
+          oldUrl: product.imageUrl,
+          newUrl: newImageUrl,
+        })
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `Corrigé ${results.length} images`,
+      results,
+    })
+  } catch (error) {
+    console.error('Erreur fix-images:', error)
+    return NextResponse.json(
+      { success: false, error: String(error) },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
Regenerate Prisma client and add an API route to fix missing product image URLs to resolve database schema errors and 404 image issues.

The `Product.displaySettings` error was caused by an outdated Prisma client referencing a column that no longer exists in the database. The 404 image errors occurred because product entries in the database pointed to non-existent image files; the new API route provides a mechanism to update these to existing placeholder images.

---
<a href="https://cursor.com/background-agent?bcId=bc-f11de6a5-830b-4952-96c0-75d271f41a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f11de6a5-830b-4952-96c0-75d271f41a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

