### PR TITLE
Changes from background agent bc-d2989277-0b3a-4be5-a21d-d0cf8f2fa484

### DIFF
--- a/app/api/checkout/session/route.ts
+++ b/app/api/checkout/session/route.ts
@@ -11,7 +11,7 @@ function getStripe() {
     throw new Error('STRIPE_SECRET_KEY manquant côté serveur')
   }
   return new Stripe(secretKey, {
-    apiVersion: '2025-08-27.basil',
+    apiVersion: '2025-07-30.basil',
   })
 }
 


### PR DESCRIPTION
Update Stripe API version to fix build failure.

The previous API version `'2025-08-27.basil'` was invalid, causing the build to fail. This updates it to the correct `'2025-07-30.basil'` version.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2989277-0b3a-4be5-a21d-d0cf8f2fa484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2989277-0b3a-4be5-a21d-d0cf8f2fa484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

