### PR TITLE
Changes from background agent bc-dd6ca2a7-13e1-484f-8a57-f643776aae1f

### DIFF
--- a/app/api/checkout/webhook/route.ts
+++ b/app/api/checkout/webhook/route.ts
@@ -11,7 +11,7 @@ function getStripe() {
     throw new Error('STRIPE_SECRET_KEY manquant côté serveur')
   }
   return new Stripe(secretKey, {
-    apiVersion: '2025-08-27.basil',
+    apiVersion: '2025-07-30.basil',
   })
 }
 


### PR DESCRIPTION
Update Stripe API version to resolve build `TypeError`.

The previous Stripe API version `'2025-08-27.basil'` was incompatible with the installed Stripe package, causing a `TypeError` during `npm run build`. This change updates the `apiVersion` to `'2025-07-30.basil'` in `app/api/checkout/webhook/route.ts` to match the expected version.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd6ca2a7-13e1-484f-8a57-f643776aae1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd6ca2a7-13e1-484f-8a57-f643776aae1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

