### PR TITLE
Fix missing order number column

### DIFF
--- a/COMMANDES_SQL_SUPABASE.md
+++ b/COMMANDES_SQL_SUPABASE.md
@@ -1,0 +1,171 @@
+# 🔧 Commandes SQL à Exécuter dans Supabase
+
+## Instructions
+
+1. Connectez-vous à votre projet Supabase
+2. Allez dans **SQL Editor**
+3. Copiez et exécutez les commandes ci-dessous **dans l'ordre**
+
+---
+
+## 📋 ÉTAPE 1 : Ajouter toutes les colonnes manquantes
+
+Copiez et exécutez ce bloc complet :
+
+```sql
+-- Ajout des colonnes d'informations de base
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "orderNumber" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "email" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "firstName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "lastName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "phone" TEXT;
+
+-- Ajout des colonnes pour Guest Checkout
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestEmail" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestPhone" TEXT;
+
+-- Ajout des colonnes d'adresse de livraison
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingAddress" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingPhone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingCity" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "ville" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "quartier" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "adresseDetaillee" TEXT;
+
+-- Ajout des colonnes de livraison
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingZone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingCents" INTEGER DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingFees" DECIMAL(10,2) DEFAULT 0;
+
+-- Ajout des colonnes de paiement
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paymentMethod" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paymentStatus" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paytechRef" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paytechToken" TEXT;
+
+-- Ajout des colonnes financières et notes
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "subtotalCents" INTEGER DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "orderNote" TEXT;
+```
+
+---
+
+## 📋 ÉTAPE 2 : Générer les numéros de commande
+
+```sql
+-- Mettre à jour les orderNumber NULL avec un numéro unique
+UPDATE "Order" 
+SET "orderNumber" = 'ORD-' || TO_CHAR(CURRENT_TIMESTAMP, 'YYYYMMDD') || '-' || LPAD(id::text, 6, '0')
+WHERE "orderNumber" IS NULL;
+```
+
+---
+
+## 📋 ÉTAPE 3 : Rendre orderNumber obligatoire et unique
+
+```sql
+-- Rendre orderNumber obligatoire
+ALTER TABLE "Order" ALTER COLUMN "orderNumber" SET NOT NULL;
+
+-- Ajouter une contrainte d'unicité
+ALTER TABLE "Order" ADD CONSTRAINT "Order_orderNumber_key" UNIQUE ("orderNumber");
+
+-- Créer un index pour les performances
+CREATE INDEX IF NOT EXISTS "Order_orderNumber_idx" ON "Order"("orderNumber");
+```
+
+---
+
+## ✅ ÉTAPE 4 : Vérifier que tout est OK
+
+Exécutez cette requête pour vérifier que toutes les colonnes sont présentes :
+
+```sql
+SELECT 
+  column_name,
+  data_type,
+  is_nullable,
+  column_default
+FROM information_schema.columns
+WHERE table_name = 'Order'
+ORDER BY ordinal_position;
+```
+
+Vous devriez maintenant voir **30 colonnes** au lieu de 6 :
+- ✅ id
+- ✅ status
+- ✅ totalCents
+- ✅ createdAt
+- ✅ updatedAt
+- ✅ userId
+- ✅ **orderNumber** ← La colonne qui manquait
+- ✅ email
+- ✅ firstName
+- ✅ lastName
+- ✅ phone
+- ✅ guestEmail
+- ✅ guestName
+- ✅ guestPhone
+- ✅ shippingAddress
+- ✅ shippingName
+- ✅ shippingPhone
+- ✅ shippingCity
+- ✅ ville
+- ✅ quartier
+- ✅ adresseDetaillee
+- ✅ shippingZone
+- ✅ shippingCents
+- ✅ shippingFees
+- ✅ paymentMethod
+- ✅ paymentStatus
+- ✅ paytechRef
+- ✅ paytechToken
+- ✅ subtotalCents
+- ✅ orderNote
+
+---
+
+## 🔍 ÉTAPE 5 : Tester avec une requête
+
+Pour vérifier que vous pouvez maintenant créer des commandes avec orderNumber :
+
+```sql
+SELECT 
+  COUNT(*) as total_colonnes,
+  COUNT(CASE WHEN column_name = 'orderNumber' THEN 1 END) as orderNumber_presente
+FROM information_schema.columns
+WHERE table_name = 'Order';
+```
+
+Résultat attendu :
+- `total_colonnes` : 30
+- `orderNumber_presente` : 1
+
+---
+
+## 🎯 Après l'exécution
+
+Une fois ces commandes exécutées :
+
+1. ✅ L'erreur `The column orderNumber does not exist` sera résolue
+2. ✅ Le checkout fonctionnera normalement
+3. ✅ Les commandes pourront être créées avec tous les champs nécessaires
+
+---
+
+## ⚠️ Note Importante
+
+Si vous avez déjà des commandes dans la base de données (actuellement 0 d'après le diagnostic), elles recevront automatiquement un `orderNumber` généré avec le format : `ORD-YYYYMMDD-XXXXXX`
+
+## 📝 Problèmes d'Images
+
+Les erreurs 404 sur les images sont un problème séparé. Vérifiez que :
+1. Les fichiers existent bien dans `/public/images/`
+2. Les noms correspondent exactement : `shampoing.jpg`, `fond-teint.jpg`, `vitamines.jpg`
+3. Les chemins d'accès sont corrects dans votre code
+
+Pour corriger les images manquantes, vous pouvez soit :
+- Ajouter les images dans `/public/images/`
+- Ou modifier les références dans votre code pour utiliser des images existantes

--- a/QUICK_FIX.sql
+++ b/QUICK_FIX.sql
@@ -1,0 +1,43 @@
+-- ========================================
+-- FIX RAPIDE : Résolution erreur orderNumber
+-- À exécuter dans Supabase SQL Editor
+-- ========================================
+
+-- 1. Ajouter toutes les colonnes manquantes
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "orderNumber" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "email" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "firstName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "lastName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "phone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestEmail" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestPhone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingAddress" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingPhone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingCity" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "ville" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "quartier" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "adresseDetaillee" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingZone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingCents" INTEGER DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingFees" DECIMAL(10,2) DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paymentMethod" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paymentStatus" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paytechRef" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paytechToken" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "subtotalCents" INTEGER DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "orderNote" TEXT;
+
+-- 2. Générer les numéros de commande
+UPDATE "Order" 
+SET "orderNumber" = 'ORD-' || TO_CHAR(CURRENT_TIMESTAMP, 'YYYYMMDD') || '-' || LPAD(id::text, 6, '0')
+WHERE "orderNumber" IS NULL;
+
+-- 3. Rendre orderNumber obligatoire et unique
+ALTER TABLE "Order" ALTER COLUMN "orderNumber" SET NOT NULL;
+ALTER TABLE "Order" ADD CONSTRAINT "Order_orderNumber_key" UNIQUE ("orderNumber");
+CREATE INDEX IF NOT EXISTS "Order_orderNumber_idx" ON "Order"("orderNumber");
+
+-- 4. Vérification finale
+SELECT COUNT(*) as total_colonnes FROM information_schema.columns WHERE table_name = 'Order';

--- a/RÉSOLUTION_ERREUR_ORDER.md
+++ b/RÉSOLUTION_ERREUR_ORDER.md
@@ -1,0 +1,227 @@
+# 🚨 Résolution de l'Erreur : The column `orderNumber` does not exist
+
+## 📋 Résumé du Problème
+
+### Erreur Principale
+```
+Invalid `prisma.order.create()` invocation:
+The column `orderNumber` does not exist in the current database.
+```
+
+### Cause
+La table `Order` dans votre base de données Supabase ne contient que **6 colonnes** au lieu des **30 colonnes** attendues par votre application. Il manque 24 colonnes essentielles, dont `orderNumber` qui est critique pour le processus de checkout.
+
+### Impact
+- ❌ Le checkout ne fonctionne pas
+- ❌ Les utilisateurs ne peuvent pas passer de commandes
+- ❌ L'application affiche une erreur 400
+
+---
+
+## ✅ Solution : 3 Étapes Simples
+
+### 📍 Étape 1 : Aller dans Supabase SQL Editor
+
+1. Connectez-vous à votre projet Supabase
+2. Cliquez sur **SQL Editor** dans le menu de gauche
+3. Cliquez sur **New query**
+
+### 📍 Étape 2 : Exécuter les Commandes SQL
+
+Copiez et collez ce bloc complet, puis cliquez sur **Run** :
+
+```sql
+-- Ajout des colonnes d'informations de base
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "orderNumber" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "email" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "firstName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "lastName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "phone" TEXT;
+
+-- Ajout des colonnes pour Guest Checkout
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestEmail" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "guestPhone" TEXT;
+
+-- Ajout des colonnes d'adresse de livraison
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingAddress" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingName" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingPhone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingCity" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "ville" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "quartier" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "adresseDetaillee" TEXT;
+
+-- Ajout des colonnes de livraison
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingZone" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingCents" INTEGER DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "shippingFees" DECIMAL(10,2) DEFAULT 0;
+
+-- Ajout des colonnes de paiement
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paymentMethod" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paymentStatus" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paytechRef" TEXT;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "paytechToken" TEXT;
+
+-- Ajout des colonnes financières et notes
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "subtotalCents" INTEGER DEFAULT 0;
+ALTER TABLE "Order" ADD COLUMN IF NOT EXISTS "orderNote" TEXT;
+
+-- Mettre à jour les orderNumber NULL avec un numéro unique
+UPDATE "Order" 
+SET "orderNumber" = 'ORD-' || TO_CHAR(CURRENT_TIMESTAMP, 'YYYYMMDD') || '-' || LPAD(id::text, 6, '0')
+WHERE "orderNumber" IS NULL;
+
+-- Rendre orderNumber obligatoire
+ALTER TABLE "Order" ALTER COLUMN "orderNumber" SET NOT NULL;
+
+-- Ajouter une contrainte d'unicité
+ALTER TABLE "Order" ADD CONSTRAINT "Order_orderNumber_key" UNIQUE ("orderNumber");
+
+-- Créer un index pour les performances
+CREATE INDEX IF NOT EXISTS "Order_orderNumber_idx" ON "Order"("orderNumber");
+```
+
+### 📍 Étape 3 : Vérifier que tout fonctionne
+
+Exécutez cette requête pour confirmer :
+
+```sql
+SELECT 
+  COUNT(*) as total_colonnes,
+  COUNT(CASE WHEN column_name = 'orderNumber' THEN 1 END) as orderNumber_presente
+FROM information_schema.columns
+WHERE table_name = 'Order';
+```
+
+**Résultat attendu :**
+- `total_colonnes` : **30** ✅
+- `orderNumber_presente` : **1** ✅
+
+---
+
+## 🎯 Après la Correction
+
+### Ce qui sera réparé :
+✅ La colonne `orderNumber` existera  
+✅ Le checkout fonctionnera normalement  
+✅ Les commandes pourront être créées  
+✅ L'erreur 400 disparaîtra  
+
+### Test Final :
+1. Retournez sur votre application
+2. Essayez de passer une commande
+3. Vérifiez qu'il n'y a plus d'erreur
+
+---
+
+## 📁 Fichiers de Documentation Créés
+
+1. **`database_schemas.md`** : Documentation complète de la structure de la base de données
+2. **`scripts/sql/02-fix-order-table.sql`** : Script SQL complet avec commentaires détaillés
+3. **`scripts/sql/03-verify-order-table.sql`** : Script de vérification après correction
+4. **`COMMANDES_SQL_SUPABASE.md`** : Guide détaillé étape par étape
+
+---
+
+## 📊 Détails Techniques
+
+### Colonnes Ajoutées (24)
+
+#### Informations de Base (5)
+- `orderNumber` - Numéro de commande unique **[CRITIQUE]**
+- `email` - Email du client
+- `firstName` - Prénom
+- `lastName` - Nom
+- `phone` - Téléphone
+
+#### Guest Checkout (3)
+- `guestEmail` - Email guest
+- `guestName` - Nom guest
+- `guestPhone` - Téléphone guest
+
+#### Adresse de Livraison (7)
+- `shippingAddress` - Adresse complète
+- `shippingName` - Nom destinataire
+- `shippingPhone` - Téléphone destinataire
+- `shippingCity` - Ville
+- `ville` - Ville (alternatif)
+- `quartier` - Quartier
+- `adresseDetaillee` - Adresse détaillée
+
+#### Livraison (3)
+- `shippingZone` - Zone (Dakar, Thiès, Autres)
+- `shippingCents` - Frais en centimes
+- `shippingFees` - Frais décimaux
+
+#### Paiement (4)
+- `paymentMethod` - Méthode (Orange Money, Wave, CB)
+- `paymentStatus` - Statut du paiement
+- `paytechRef` - Référence PayTech
+- `paytechToken` - Token PayTech
+
+#### Autres (2)
+- `subtotalCents` - Sous-total en centimes
+- `orderNote` - Note du client
+
+---
+
+## ⚠️ Problèmes Secondaires (Images 404)
+
+Les erreurs d'images sont un problème séparé :
+```
+❌ /images/shampoing.jpg - 404
+❌ /images/fond-teint.jpg - 404
+❌ /images/vitamines.jpg - 404
+```
+
+### Solutions :
+1. Vérifiez que les fichiers existent dans `/public/images/`
+2. Vérifiez les noms de fichiers (sensible à la casse)
+3. Remplacez par des images existantes ou des placeholders
+
+---
+
+## 🆘 Besoin d'Aide ?
+
+Si vous rencontrez des problèmes :
+
+1. **Vérifiez les permissions** : Assurez-vous d'avoir les droits d'admin sur Supabase
+2. **Vérifiez la connexion** : La base de données doit être accessible
+3. **Relancez l'app** : Redémarrez votre application après la correction
+4. **Consultez les logs** : Vérifiez les erreurs dans la console Supabase
+
+---
+
+## 📈 Progression
+
+Avant :
+```
+Table Order : 6 colonnes ❌
+Checkout : Non fonctionnel ❌
+Erreur : orderNumber does not exist ❌
+```
+
+Après :
+```
+Table Order : 30 colonnes ✅
+Checkout : Fonctionnel ✅
+Erreur : Résolue ✅
+```
+
+---
+
+## 🚀 Prochaines Étapes
+
+Après avoir corrigé la base de données :
+
+1. ✅ Testez le checkout complet
+2. ✅ Vérifiez la création de commandes
+3. ✅ Testez avec un utilisateur connecté
+4. ✅ Testez avec un guest checkout
+5. ✅ Configurez PayTech pour les paiements
+6. ✅ Ajoutez les images manquantes
+
+---
+
+**Bonne chance ! 🎉**

--- a/database_schemas.md
+++ b/database_schemas.md
@@ -1,0 +1,257 @@
+# Structure de la Base de Données - FlawlessBeauty
+
+## Diagnostic de la Base de Données
+
+### Tables Existantes
+
+| Table | Type | Nombre de Colonnes | Contraintes |
+|-------|------|-------------------|-------------|
+| Address | BASE TABLE | 110 | 3 |
+| Brand | BASE TABLE | 36 | 2 |
+| Cart | BASE TABLE | 24 | 3 |
+| CartItem | BASE TABLE | 28 | 3 |
+| Category | BASE TABLE | 36 | 2 |
+| Order | BASE TABLE | 48 | 3 |
+| OrderItem | BASE TABLE | 40 | 3 |
+| Product | BASE TABLE | 168 | 3 |
+| Review | BASE TABLE | 48 | 3 |
+| Subcategory | BASE TABLE | 24 | 3 |
+| User | BASE TABLE | 30 | 2 |
+| contact_messages | BASE TABLE | 48 | 2 |
+| newsletter_subscribers | BASE TABLE | 20 | 3 |
+| order_items | BASE TABLE | 100 | 3 |
+| orders | BASE TABLE | 112 | 4 |
+| profiles | BASE TABLE | 21 | 3 |
+| shipping_methods | BASE TABLE | 32 | 2 |
+| user_addresses | BASE TABLE | 80 | 3 |
+| user_favorites | BASE TABLE | 28 | 4 |
+| user_roles | BASE TABLE | 28 | 4 |
+| user_suspensions | BASE TABLE | 56 | 4 |
+
+### Données Actuelles
+
+| Table | Nombre d'enregistrements |
+|-------|-------------------------|
+| Brand | 30 |
+| Cart | 3 |
+| CartItem | 0 |
+| Category | 10 |
+| Order | 0 |
+| OrderItem | 0 |
+| Product | 16 |
+| Subcategory | 46 |
+| User | 3 |
+
+## Structure de la Table Order (ACTUELLE)
+
+### Colonnes Existantes
+
+| Colonne | Type | Longueur Max | Défaut | Nullable |
+|---------|------|-------------|--------|----------|
+| id | text | null | null | NO |
+| status | OrderStatus (ENUM) | null | 'PENDING' | NO |
+| totalCents | integer | null | 0 | NO |
+| createdAt | timestamp | null | CURRENT_TIMESTAMP | NO |
+| updatedAt | timestamp | null | null | NO |
+| userId | text | null | null | NO |
+
+### Contraintes
+
+| Nom | Type | Colonne |
+|-----|------|---------|
+| Order_pkey | PRIMARY KEY | id |
+| Order_userId_fkey | FOREIGN KEY | userId → User.id |
+
+### Enum OrderStatus
+
+- PENDING
+- PAID
+- SHIPPED
+- CANCELLED
+
+## 🚨 PROBLÈME IDENTIFIÉ : Colonnes Manquantes dans Order
+
+### Colonnes Manquantes (24 colonnes)
+
+❌ **Informations de Base**
+- `orderNumber` - **CRITIQUE** (cause l'erreur actuelle)
+- `email`
+- `firstName`
+- `lastName`
+- `phone`
+
+❌ **Informations Guest Checkout**
+- `guestEmail`
+- `guestName`
+- `guestPhone`
+
+❌ **Informations d'Adresse**
+- `shippingAddress`
+- `shippingName`
+- `shippingPhone`
+- `shippingCity`
+- `ville`
+- `quartier`
+- `adresseDetaillee`
+
+❌ **Informations de Livraison**
+- `shippingZone`
+- `shippingCents`
+- `shippingFees`
+
+❌ **Informations de Paiement**
+- `paymentMethod`
+- `paymentStatus`
+- `paytechRef`
+- `paytechToken`
+
+❌ **Autres**
+- `subtotalCents`
+- `orderNote`
+
+## Impact de l'Erreur
+
+L'erreur actuelle provient de la tentative de créer une commande avec la colonne `orderNumber` qui n'existe pas :
+
+```
+Invalid `prisma.order.create()` invocation:
+The column `orderNumber` does not exist in the current database.
+```
+
+Cette erreur bloque complètement le processus de checkout et empêche les utilisateurs de passer des commandes.
+
+## Solution Requise
+
+Il faut exécuter un script SQL ALTER TABLE pour ajouter toutes les colonnes manquantes à la table Order avec les types et contraintes appropriés.
+
+---
+
+## Structure de la Table Order (APRÈS CORRECTION)
+
+### Colonnes Complètes (30 colonnes)
+
+#### Colonnes Existantes (6)
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| id | text | NO | null | Identifiant unique |
+| status | OrderStatus | NO | 'PENDING' | Statut de la commande |
+| totalCents | integer | NO | 0 | Montant total en centimes |
+| createdAt | timestamp | NO | CURRENT_TIMESTAMP | Date de création |
+| updatedAt | timestamp | NO | null | Date de mise à jour |
+| userId | text | NO | null | ID de l'utilisateur |
+
+#### Colonnes à Ajouter (24)
+
+**Informations de Base**
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| orderNumber | text | NO | null | Numéro de commande unique (ORD-YYYYMMDD-XXXXXX) |
+| email | text | YES | null | Email du client |
+| firstName | text | YES | null | Prénom du client |
+| lastName | text | YES | null | Nom du client |
+| phone | text | YES | null | Téléphone du client |
+
+**Guest Checkout**
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| guestEmail | text | YES | null | Email du guest (commande sans compte) |
+| guestName | text | YES | null | Nom complet du guest |
+| guestPhone | text | YES | null | Téléphone du guest |
+
+**Adresse de Livraison**
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| shippingAddress | text | YES | null | Adresse de livraison complète |
+| shippingName | text | YES | null | Nom du destinataire |
+| shippingPhone | text | YES | null | Téléphone du destinataire |
+| shippingCity | text | YES | null | Ville de livraison |
+| ville | text | YES | null | Ville (champ alternatif) |
+| quartier | text | YES | null | Quartier |
+| adresseDetaillee | text | YES | null | Adresse détaillée |
+
+**Livraison**
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| shippingZone | text | YES | null | Zone de livraison (Dakar, Thiès, Autres) |
+| shippingCents | integer | YES | 0 | Frais de livraison en centimes |
+| shippingFees | decimal(10,2) | YES | 0 | Frais de livraison (format décimal) |
+
+**Paiement**
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| paymentMethod | text | YES | null | Méthode de paiement (Orange Money, Wave, CB) |
+| paymentStatus | text | YES | null | Statut du paiement |
+| paytechRef | text | YES | null | Référence PayTech |
+| paytechToken | text | YES | null | Token PayTech |
+
+**Autres**
+| Colonne | Type | Nullable | Défaut | Description |
+|---------|------|----------|--------|-------------|
+| subtotalCents | integer | YES | 0 | Sous-total en centimes (avant frais de livraison) |
+| orderNote | text | YES | null | Note de commande du client |
+
+### Contraintes (Après Correction)
+
+| Nom | Type | Colonne | Description |
+|-----|------|---------|-------------|
+| Order_pkey | PRIMARY KEY | id | Clé primaire |
+| Order_userId_fkey | FOREIGN KEY | userId → User.id | Relation utilisateur |
+| Order_orderNumber_key | UNIQUE | orderNumber | Unicité du numéro de commande |
+
+### Index (Après Correction)
+
+| Nom | Colonnes | Type | Description |
+|-----|----------|------|-------------|
+| Order_pkey | id | PRIMARY | Index de clé primaire |
+| Order_orderNumber_idx | orderNumber | INDEX | Index pour recherches rapides |
+
+---
+
+## Scripts SQL de Correction
+
+Les scripts SQL pour corriger la base de données sont disponibles dans :
+
+1. **`scripts/sql/02-fix-order-table.sql`** : Script complet de correction avec commentaires détaillés
+2. **`scripts/sql/03-verify-order-table.sql`** : Script de vérification après correction
+3. **`COMMANDES_SQL_SUPABASE.md`** : Guide étape par étape pour Supabase SQL Editor
+
+---
+
+## Étapes de Correction
+
+### 1. Exécuter les Commandes SQL
+Suivre les instructions dans `COMMANDES_SQL_SUPABASE.md` :
+- Étape 1 : Ajouter les colonnes
+- Étape 2 : Générer les numéros de commande
+- Étape 3 : Ajouter les contraintes
+- Étape 4 : Vérifier la structure
+
+### 2. Vérifier la Correction
+Exécuter `scripts/sql/03-verify-order-table.sql` pour valider :
+- ✅ 30 colonnes présentes
+- ✅ Contrainte unique sur orderNumber
+- ✅ Index créé
+- ✅ Aucune commande orpheline
+
+### 3. Tester l'Application
+- Redémarrer l'application
+- Tester le processus de checkout
+- Vérifier la création de commandes
+- Confirmer que l'erreur `orderNumber does not exist` est résolue
+
+---
+
+## Problèmes Additionnels Identifiés
+
+### Images 404
+```
+/images/shampoing.jpg - 404
+/images/fond-teint.jpg - 404
+/images/vitamines.jpg - 404
+```
+
+**Solutions possibles :**
+1. Vérifier que les fichiers existent dans `/public/images/`
+2. Vérifier les noms de fichiers (sensible à la casse)
+3. Utiliser des images de remplacement
+4. Vérifier la configuration Next.js pour les images statiques

--- a/scripts/sql/02-fix-order-table.sql
+++ b/scripts/sql/02-fix-order-table.sql
@@ -1,266 +1,154 @@
 -- =====================================================
--- SCRIPT DE CORRECTION DE LA TABLE "Order"
--- =====================================================
--- Ce script ajoute les colonnes manquantes à la table Order
--- Exécutez ce script après avoir vérifié avec 01-diagnostic-database.sql
+-- Script de correction de la table Order
+-- Ajoute toutes les colonnes manquantes identifiées
 -- =====================================================
 
--- ATTENTION : Sauvegardez vos données avant d'exécuter ce script !
--- CRÉEZ UNE SAUVEGARDE :
--- SELECT * INTO "Order_backup" FROM "Order";
-
+-- ÉTAPE 1 : Ajouter les colonnes d'informations de base
 -- =====================================================
--- ÉTAPE 1 : AJOUTER LA COLONNE orderNumber SI MANQUANTE
+
+-- Numéro de commande (CRITIQUE - cause l'erreur actuelle)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "orderNumber" TEXT;
+
+-- Email du client
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "email" TEXT;
+
+-- Prénom du client
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "firstName" TEXT;
+
+-- Nom du client
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "lastName" TEXT;
+
+-- Téléphone du client
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "phone" TEXT;
+
+-- ÉTAPE 2 : Ajouter les colonnes pour Guest Checkout
 -- =====================================================
-DO $$ 
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM information_schema.columns 
-        WHERE table_schema = 'public' 
-        AND table_name = 'Order' 
-        AND column_name = 'orderNumber'
-    ) THEN
-        ALTER TABLE "Order" ADD COLUMN "orderNumber" TEXT;
-        
-        -- Générer des orderNumber uniques pour les commandes existantes
-        UPDATE "Order" SET "orderNumber" = 'ORD-' || LPAD(CAST(ROW_NUMBER() OVER (ORDER BY "createdAt") AS TEXT), 8, '0')
-        WHERE "orderNumber" IS NULL;
-        
-        -- Rendre la colonne NOT NULL et UNIQUE
-        ALTER TABLE "Order" ALTER COLUMN "orderNumber" SET NOT NULL;
-        ALTER TABLE "Order" ADD CONSTRAINT "Order_orderNumber_key" UNIQUE ("orderNumber");
-        
-        RAISE NOTICE 'Colonne orderNumber ajoutée avec succès';
-    ELSE
-        RAISE NOTICE 'Colonne orderNumber existe déjà';
-    END IF;
-END $$;
 
+-- Email du guest (pour commandes sans compte)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "guestEmail" TEXT;
+
+-- Nom complet du guest
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "guestName" TEXT;
+
+-- Téléphone du guest
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "guestPhone" TEXT;
+
+-- ÉTAPE 3 : Ajouter les colonnes d'adresse de livraison
 -- =====================================================
--- ÉTAPE 2 : AJOUTER LES COLONNES GUEST CHECKOUT SI MANQUANTES
+
+-- Adresse de livraison complète
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingAddress" TEXT;
+
+-- Nom du destinataire
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingName" TEXT;
+
+-- Téléphone du destinataire
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingPhone" TEXT;
+
+-- Ville de livraison
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingCity" TEXT;
+
+-- Ville (champ alternatif)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "ville" TEXT;
+
+-- Quartier
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "quartier" TEXT;
+
+-- Adresse détaillée
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "adresseDetaillee" TEXT;
+
+-- ÉTAPE 4 : Ajouter les colonnes de livraison
 -- =====================================================
-DO $$ 
-BEGIN
-    -- firstName
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'firstName') THEN
-        ALTER TABLE "Order" ADD COLUMN "firstName" TEXT;
-        UPDATE "Order" SET "firstName" = COALESCE("guestName", "shippingName", 'Client') WHERE "firstName" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "firstName" SET NOT NULL;
-        RAISE NOTICE 'Colonne firstName ajoutée';
-    END IF;
 
-    -- lastName
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'lastName') THEN
-        ALTER TABLE "Order" ADD COLUMN "lastName" TEXT;
-        UPDATE "Order" SET "lastName" = '' WHERE "lastName" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "lastName" SET NOT NULL;
-        RAISE NOTICE 'Colonne lastName ajoutée';
-    END IF;
+-- Zone de livraison (Dakar, Thiès, Autres)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingZone" TEXT;
 
-    -- email
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'email') THEN
-        ALTER TABLE "Order" ADD COLUMN "email" TEXT;
-        UPDATE "Order" SET "email" = COALESCE("guestEmail", 'noemail@example.com') WHERE "email" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "email" SET NOT NULL;
-        RAISE NOTICE 'Colonne email ajoutée';
-    END IF;
+-- Frais de livraison en centimes
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingCents" INTEGER DEFAULT 0;
 
-    -- phone
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'phone') THEN
-        ALTER TABLE "Order" ADD COLUMN "phone" TEXT;
-        UPDATE "Order" SET "phone" = COALESCE("guestPhone", "shippingPhone", '') WHERE "phone" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "phone" SET NOT NULL;
-        RAISE NOTICE 'Colonne phone ajoutée';
-    END IF;
-END $$;
+-- Frais de livraison (format décimal)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "shippingFees" DECIMAL(10,2) DEFAULT 0;
 
+-- ÉTAPE 5 : Ajouter les colonnes de paiement
 -- =====================================================
--- ÉTAPE 3 : AJOUTER LES COLONNES D'ADRESSE DÉTAILLÉE
+
+-- Méthode de paiement (Orange Money, Wave, CB)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "paymentMethod" TEXT;
+
+-- Statut du paiement
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "paymentStatus" TEXT;
+
+-- Référence PayTech
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "paytechRef" TEXT;
+
+-- Token PayTech
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "paytechToken" TEXT;
+
+-- ÉTAPE 6 : Ajouter les colonnes financières et notes
 -- =====================================================
-DO $$ 
-BEGIN
-    -- ville
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'ville') THEN
-        ALTER TABLE "Order" ADD COLUMN "ville" TEXT;
-        UPDATE "Order" SET "ville" = COALESCE("shippingCity", 'Dakar') WHERE "ville" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "ville" SET NOT NULL;
-        RAISE NOTICE 'Colonne ville ajoutée';
-    END IF;
 
-    -- quartier
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'quartier') THEN
-        ALTER TABLE "Order" ADD COLUMN "quartier" TEXT;
-        UPDATE "Order" SET "quartier" = COALESCE("shippingAddress", '') WHERE "quartier" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "quartier" SET NOT NULL;
-        RAISE NOTICE 'Colonne quartier ajoutée';
-    END IF;
+-- Sous-total en centimes (avant frais de livraison)
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "subtotalCents" INTEGER DEFAULT 0;
 
-    -- adresseDetaillee
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'adresseDetaillee') THEN
-        ALTER TABLE "Order" ADD COLUMN "adresseDetaillee" TEXT;
-        UPDATE "Order" SET "adresseDetaillee" = COALESCE("shippingAddress", '') WHERE "adresseDetaillee" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "adresseDetaillee" SET NOT NULL;
-        RAISE NOTICE 'Colonne adresseDetaillee ajoutée';
-    END IF;
+-- Note de commande du client
+ALTER TABLE "Order" 
+ADD COLUMN IF NOT EXISTS "orderNote" TEXT;
 
-    -- orderNote (optionnel)
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'orderNote') THEN
-        ALTER TABLE "Order" ADD COLUMN "orderNote" TEXT;
-        RAISE NOTICE 'Colonne orderNote ajoutée';
-    END IF;
-END $$;
-
+-- ÉTAPE 7 : Générer les numéros de commande pour les commandes existantes (si besoin)
 -- =====================================================
--- ÉTAPE 4 : VÉRIFIER/AJOUTER LES COLONNES LEGACY
+
+-- Mise à jour des orderNumber NULL avec un numéro unique
+UPDATE "Order" 
+SET "orderNumber" = 'ORD-' || TO_CHAR(CURRENT_TIMESTAMP, 'YYYYMMDD') || '-' || LPAD(id::text, 6, '0')
+WHERE "orderNumber" IS NULL;
+
+-- ÉTAPE 8 : Rendre orderNumber obligatoire
 -- =====================================================
-DO $$ 
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'guestEmail') THEN
-        ALTER TABLE "Order" ADD COLUMN "guestEmail" TEXT;
-        RAISE NOTICE 'Colonne guestEmail ajoutée';
-    END IF;
 
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'guestName') THEN
-        ALTER TABLE "Order" ADD COLUMN "guestName" TEXT;
-        RAISE NOTICE 'Colonne guestName ajoutée';
-    END IF;
+-- Ajouter la contrainte NOT NULL sur orderNumber
+ALTER TABLE "Order" 
+ALTER COLUMN "orderNumber" SET NOT NULL;
 
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'guestPhone') THEN
-        ALTER TABLE "Order" ADD COLUMN "guestPhone" TEXT;
-        RAISE NOTICE 'Colonne guestPhone ajoutée';
-    END IF;
+-- Ajouter une contrainte d'unicité sur orderNumber
+ALTER TABLE "Order" 
+ADD CONSTRAINT "Order_orderNumber_key" UNIQUE ("orderNumber");
 
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'shippingName') THEN
-        ALTER TABLE "Order" ADD COLUMN "shippingName" TEXT;
-        RAISE NOTICE 'Colonne shippingName ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'shippingPhone') THEN
-        ALTER TABLE "Order" ADD COLUMN "shippingPhone" TEXT;
-        RAISE NOTICE 'Colonne shippingPhone ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'shippingAddress') THEN
-        ALTER TABLE "Order" ADD COLUMN "shippingAddress" TEXT;
-        RAISE NOTICE 'Colonne shippingAddress ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'shippingCity') THEN
-        ALTER TABLE "Order" ADD COLUMN "shippingCity" TEXT;
-        RAISE NOTICE 'Colonne shippingCity ajoutée';
-    END IF;
-END $$;
-
+-- ÉTAPE 9 : Créer un index sur orderNumber pour les performances
 -- =====================================================
--- ÉTAPE 5 : VÉRIFIER/CRÉER LES ENUMS SI NÉCESSAIRE
+
+CREATE INDEX IF NOT EXISTS "Order_orderNumber_idx" ON "Order"("orderNumber");
+
+-- ÉTAPE 10 : Afficher le résumé des colonnes
 -- =====================================================
-DO $$ 
-BEGIN
-    -- ShippingZone enum
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ShippingZone') THEN
-        CREATE TYPE "ShippingZone" AS ENUM ('DAKAR', 'THIES', 'AUTRE');
-        RAISE NOTICE 'Type ENUM ShippingZone créé';
-    END IF;
 
-    -- PaymentMethod enum
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PaymentMethod') THEN
-        CREATE TYPE "PaymentMethod" AS ENUM ('ORANGE_MONEY', 'WAVE', 'CARD', 'CASH_ON_DELIVERY');
-        RAISE NOTICE 'Type ENUM PaymentMethod créé';
-    END IF;
-
-    -- PaymentStatus enum
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PaymentStatus') THEN
-        CREATE TYPE "PaymentStatus" AS ENUM ('PENDING', 'PROCESSING', 'PAID', 'FAILED', 'CANCELLED', 'REFUNDED');
-        RAISE NOTICE 'Type ENUM PaymentStatus créé';
-    END IF;
-
-    -- OrderStatus enum
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'OrderStatus') THEN
-        CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'CONFIRMED', 'PROCESSING', 'SHIPPED', 'DELIVERED', 'CANCELLED');
-        RAISE NOTICE 'Type ENUM OrderStatus créé';
-    END IF;
-END $$;
-
--- =====================================================
--- ÉTAPE 6 : AJOUTER LES COLONNES ENUM SI MANQUANTES
--- =====================================================
-DO $$ 
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'shippingZone') THEN
-        ALTER TABLE "Order" ADD COLUMN "shippingZone" "ShippingZone" DEFAULT 'DAKAR';
-        UPDATE "Order" SET "shippingZone" = 'DAKAR' WHERE "shippingZone" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "shippingZone" SET NOT NULL;
-        RAISE NOTICE 'Colonne shippingZone ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'paymentMethod') THEN
-        ALTER TABLE "Order" ADD COLUMN "paymentMethod" "PaymentMethod" DEFAULT 'ORANGE_MONEY';
-        UPDATE "Order" SET "paymentMethod" = 'ORANGE_MONEY' WHERE "paymentMethod" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "paymentMethod" SET NOT NULL;
-        RAISE NOTICE 'Colonne paymentMethod ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'paymentStatus') THEN
-        ALTER TABLE "Order" ADD COLUMN "paymentStatus" "PaymentStatus" DEFAULT 'PENDING';
-        UPDATE "Order" SET "paymentStatus" = 'PENDING' WHERE "paymentStatus" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "paymentStatus" SET NOT NULL;
-        RAISE NOTICE 'Colonne paymentStatus ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'status') THEN
-        ALTER TABLE "Order" ADD COLUMN "status" "OrderStatus" DEFAULT 'PENDING';
-        UPDATE "Order" SET "status" = 'PENDING' WHERE "status" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "status" SET NOT NULL;
-        RAISE NOTICE 'Colonne status ajoutée';
-    END IF;
-END $$;
-
--- =====================================================
--- ÉTAPE 7 : AJOUTER LES COLONNES PAYTECH
--- =====================================================
-DO $$ 
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'paytechToken') THEN
-        ALTER TABLE "Order" ADD COLUMN "paytechToken" TEXT;
-        RAISE NOTICE 'Colonne paytechToken ajoutée';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'paytechRef') THEN
-        ALTER TABLE "Order" ADD COLUMN "paytechRef" TEXT;
-        RAISE NOTICE 'Colonne paytechRef ajoutée';
-    END IF;
-END $$;
-
--- =====================================================
--- ÉTAPE 8 : AJOUTER LES COLONNES DE FRAIS
--- =====================================================
-DO $$ 
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'Order' AND column_name = 'shippingFees') THEN
-        ALTER TABLE "Order" ADD COLUMN "shippingFees" INTEGER DEFAULT 0;
-        UPDATE "Order" SET "shippingFees" = 0 WHERE "shippingFees" IS NULL;
-        ALTER TABLE "Order" ALTER COLUMN "shippingFees" SET NOT NULL;
-        RAISE NOTICE 'Colonne shippingFees ajoutée';
-    END IF;
-END $$;
-
--- =====================================================
--- VÉRIFICATION FINALE
--- =====================================================
 SELECT 
-    'Vérification finale de la table Order' AS message,
-    COUNT(*) as nombre_colonnes
+  column_name,
+  data_type,
+  is_nullable,
+  column_default
 FROM information_schema.columns
-WHERE table_schema = 'public' 
-    AND table_name = 'Order';
-
--- Afficher toutes les colonnes de la table Order
-SELECT 
-    column_name,
-    data_type,
-    is_nullable,
-    column_default
-FROM information_schema.columns
-WHERE table_schema = 'public' 
-    AND table_name = 'Order'
+WHERE table_name = 'Order'
 ORDER BY ordinal_position;

--- a/scripts/sql/03-verify-order-table.sql
+++ b/scripts/sql/03-verify-order-table.sql
@@ -1,0 +1,120 @@
+-- =====================================================
+-- Script de vérification de la table Order
+-- À exécuter après avoir appliqué les corrections
+-- =====================================================
+
+-- VÉRIFICATION 1 : Compter les colonnes de la table Order
+-- =====================================================
+SELECT 
+  'Nombre total de colonnes' as verification,
+  COUNT(*) as valeur
+FROM information_schema.columns
+WHERE table_name = 'Order';
+
+-- VÉRIFICATION 2 : Vérifier que les colonnes critiques existent
+-- =====================================================
+SELECT 
+  CASE 
+    WHEN column_name = 'orderNumber' THEN '✅ orderNumber'
+    WHEN column_name = 'email' THEN '✅ email'
+    WHEN column_name = 'firstName' THEN '✅ firstName'
+    WHEN column_name = 'lastName' THEN '✅ lastName'
+    WHEN column_name = 'phone' THEN '✅ phone'
+    WHEN column_name = 'guestEmail' THEN '✅ guestEmail'
+    WHEN column_name = 'guestName' THEN '✅ guestName'
+    WHEN column_name = 'guestPhone' THEN '✅ guestPhone'
+    WHEN column_name = 'shippingAddress' THEN '✅ shippingAddress'
+    WHEN column_name = 'shippingName' THEN '✅ shippingName'
+    WHEN column_name = 'shippingPhone' THEN '✅ shippingPhone'
+    WHEN column_name = 'shippingCity' THEN '✅ shippingCity'
+    WHEN column_name = 'ville' THEN '✅ ville'
+    WHEN column_name = 'quartier' THEN '✅ quartier'
+    WHEN column_name = 'adresseDetaillee' THEN '✅ adresseDetaillee'
+    WHEN column_name = 'shippingZone' THEN '✅ shippingZone'
+    WHEN column_name = 'shippingCents' THEN '✅ shippingCents'
+    WHEN column_name = 'shippingFees' THEN '✅ shippingFees'
+    WHEN column_name = 'paymentMethod' THEN '✅ paymentMethod'
+    WHEN column_name = 'paymentStatus' THEN '✅ paymentStatus'
+    WHEN column_name = 'paytechRef' THEN '✅ paytechRef'
+    WHEN column_name = 'paytechToken' THEN '✅ paytechToken'
+    WHEN column_name = 'subtotalCents' THEN '✅ subtotalCents'
+    WHEN column_name = 'orderNote' THEN '✅ orderNote'
+    ELSE column_name
+  END as colonne,
+  data_type as type,
+  CASE 
+    WHEN is_nullable = 'YES' THEN 'NULL autorisé'
+    ELSE 'NOT NULL'
+  END as nullable,
+  COALESCE(column_default, 'Aucune') as defaut
+FROM information_schema.columns
+WHERE table_name = 'Order'
+  AND column_name IN (
+    'orderNumber', 'email', 'firstName', 'lastName', 'phone',
+    'guestEmail', 'guestName', 'guestPhone',
+    'shippingAddress', 'shippingName', 'shippingPhone', 'shippingCity',
+    'ville', 'quartier', 'adresseDetaillee',
+    'shippingZone', 'shippingCents', 'shippingFees',
+    'paymentMethod', 'paymentStatus', 'paytechRef', 'paytechToken',
+    'subtotalCents', 'orderNote'
+  )
+ORDER BY column_name;
+
+-- VÉRIFICATION 3 : Vérifier les contraintes
+-- =====================================================
+SELECT 
+  constraint_name as contrainte,
+  constraint_type as type,
+  STRING_AGG(column_name, ', ') as colonnes
+FROM information_schema.constraint_column_usage
+JOIN information_schema.table_constraints USING (constraint_name, table_name)
+WHERE table_name = 'Order'
+GROUP BY constraint_name, constraint_type
+ORDER BY constraint_type, constraint_name;
+
+-- VÉRIFICATION 4 : Vérifier les index
+-- =====================================================
+SELECT 
+  indexname as index,
+  indexdef as definition
+FROM pg_indexes
+WHERE tablename = 'Order'
+ORDER BY indexname;
+
+-- VÉRIFICATION 5 : Statistiques de la table
+-- =====================================================
+SELECT 
+  'Statistiques de la table Order' as info,
+  COUNT(*) as nombre_commandes
+FROM "Order";
+
+-- VÉRIFICATION 6 : Schéma complet de la table
+-- =====================================================
+SELECT 
+  column_name as colonne,
+  data_type as type,
+  character_maximum_length as longueur_max,
+  is_nullable as nullable,
+  column_default as defaut
+FROM information_schema.columns
+WHERE table_name = 'Order'
+ORDER BY ordinal_position;
+
+-- VÉRIFICATION 7 : Test de contrainte unique sur orderNumber
+-- =====================================================
+SELECT 
+  constraint_name,
+  constraint_type
+FROM information_schema.table_constraints
+WHERE table_name = 'Order' 
+  AND constraint_type = 'UNIQUE'
+  AND constraint_name LIKE '%orderNumber%';
+
+-- VÉRIFICATION 8 : Résumé final
+-- =====================================================
+SELECT 
+  'RÉSUMÉ DE VÉRIFICATION' as titre,
+  (SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'Order') as total_colonnes,
+  (SELECT COUNT(*) FROM information_schema.table_constraints WHERE table_name = 'Order') as total_contraintes,
+  (SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'Order') as total_index,
+  (SELECT COUNT(*) FROM "Order") as total_commandes;


### PR DESCRIPTION
Add missing columns to the `Order` table, including `orderNumber`, and enforce `orderNumber` uniqueness to fix checkout errors.

The `prisma.order.create()` invocation was failing with "The column `orderNumber` does not exist in the current database." This PR adds `orderNumber` and 23 other missing columns to the `Order` table, along with necessary constraints and an index, to enable proper order creation and restore checkout functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-a46a791d-382b-477a-9f85-27586026089a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a46a791d-382b-477a-9f85-27586026089a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

