### PR TITLE
Changes from background agent bc-1ccb8e11-088f-46ee-b30e-fe992731b7ae

### DIFF
--- a/app/test-env/page.tsx
+++ b/app/test-env/page.tsx
@@ -54,7 +54,9 @@ export default function TestEnvPage() {
     SUPABASE_SERVICE_ROLE_KEY: envVars.SUPABASE_SERVICE_ROLE_KEY,
   }
 
-  const allCriticalConfigured = Object.values(criticalVars).every(v => v === true || v !== 'NOT SET')
+  const allCriticalConfigured = Object.values(criticalVars).every(v => 
+    typeof v === 'boolean' ? v === true : v !== 'NOT SET'
+  )
   const missingCritical = Object.entries(criticalVars)
     .filter(([, value]) => !value || value === 'NOT SET')
     .map(([key]) => key)


### PR DESCRIPTION
Fix TypeScript type comparison error in `app/test-env/page.tsx` to resolve Vercel build failure.

The previous logic `v === true || v !== 'NOT SET'` caused a TypeScript error due to an unintentional comparison between `boolean` and `string` types. The fix explicitly checks the type of `v` before comparison, ensuring `v === true` for booleans and `v !== 'NOT SET'` for strings.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ccb8e11-088f-46ee-b30e-fe992731b7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ccb8e11-088f-46ee-b30e-fe992731b7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

